### PR TITLE
BUG: Fix bug with naming

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [aliases]
 test = pytest


### PR DESCRIPTION
Should fix a bug with setuptools 78:

https://app.circleci.com/pipelines/github/mne-tools/mne-python/26988/workflows/e0106eb0-3945-4700-bb3a-ce3b60283d45/jobs/72244

```
Collecting sesameeg
  Downloading sesameeg-0.0.2.tar.gz (34 kB)
  Running command pip subprocess to install build dependencies
  Using pip 25.0.1 from /home/circleci/python_env/lib/python3.12/site-packages/pip (python 3.12)
  Collecting setuptools>=40.8.0
    Obtaining dependency information for setuptools>=40.8.0 from https://files.pythonhosted.org/packages/42/c8/3faed884acdb2c1f2eb353cbacdd1ee4943de89a199d1f622ebefb6170e5/setuptools-78.0.1-py3-none-any.whl.metadata
    Using cached setuptools-78.0.1-py3-none-any.whl.metadata (6.6 kB)
  Using cached setuptools-78.0.1-py3-none-any.whl (1.3 MB)
  Installing collected packages: setuptools
  Successfully installed setuptools-78.0.1
  Installing build dependencies ... done
  Running command Getting requirements to build wheel
  Traceback (most recent call last):
    File "/home/circleci/python_env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
      main()
    ...
    File "/tmp/pip-build-env-1ocdif2u/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 599, in _parse_config_files
      opt = self._enforce_underscore(opt, section)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/pip-build-env-1ocdif2u/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 629, in _enforce_underscore
      raise InvalidConfigError(
  setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.
```

I'd recommend merging and cutting a 0.3 ASAP to avoid people having errors with `pip install sesameeg`.